### PR TITLE
bug fix & add support for manually setting page title

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,6 @@
+#page title
+page_title                                :                                           # Automatically populates with app name if not set and if iOS app ID is set. Otherwise enter manually.
+
 # App Info
 ios_app_id                                : 1234793120                                # Required. Enter iOS app ID to automatically populate name, price and icons (e.g. 718043190).
 

--- a/_includes/appstoreimages.html
+++ b/_includes/appstoreimages.html
@@ -23,7 +23,7 @@ $(function() {
             if ($.trim($($pageTitle).text()).length == 0) {
                 $($pageTitle).html(appInfo.trackName);
             }
-            
+
             // Set large app icon using the iOS app ID if it is not set manually in _config.yml
             var $appIconLarge = $(".appIconLarge");
             if (!$appIconLarge.attr('src')) {
@@ -51,8 +51,8 @@ $(function() {
             }
 
             // Set App Store link using the iOS app ID if it is not set manually in _config.yml
-            var $appStoreLink = $(".appStoreLink").attr('href');
-            if ($.trim($appStoreLink).length == 0) {
+            var $appStoreLink = $(".appStoreLink");
+            if ($.trim($appStoreLink.attr('href')).length == 0) {
                 $($appStoreLink).attr("href", appInfo.trackViewUrl);
             }
 

--- a/_includes/appstoreimages.html
+++ b/_includes/appstoreimages.html
@@ -18,6 +18,12 @@ $(function() {
             // Set favicon
             $('link[rel="shortcut icon"]').attr("href", appInfo.artworkUrl512);
 
+            // Set page title using the iOS app ID if it is not set manually in _config.yml
+            var $pageTitle = $(".pageTitle");
+            if ($.trim($($pageTitle).text()).length == 0) {
+                $($pageTitle).html(appInfo.trackName);
+            }
+            
             // Set large app icon using the iOS app ID if it is not set manually in _config.yml
             var $appIconLarge = $(".appIconLarge");
             if (!$appIconLarge.attr('src')) {

--- a/_includes/appstoreimages.html
+++ b/_includes/appstoreimages.html
@@ -44,9 +44,9 @@ $(function() {
                 $($appPrice).html(appInfo.formattedPrice);
             }
 
-            // Set price using the iOS app ID if it is not set manually in _config.yml
-            var $appStoreLink = $(".appStoreLink");
-            if ($.trim($($appStoreLink).text()).length == 0) {
+            // Set App Store link using the iOS app ID if it is not set manually in _config.yml
+            var $appStoreLink = $(".appStoreLink").attr('href');
+            if ($.trim($appStoreLink).length == 0) {
                 $($appStoreLink).attr("href", appInfo.trackViewUrl);
             }
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<base target="_blank">
 
-	<title>{{ site.app_name }}</title>
+	<title class="pageTitle">{{ site.page_title }}</title>
 	<meta name="description" content="{{ site.app_description }}">
 
 	<link rel="shortcut icon" href="{{ site.app_icon }}">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -52,9 +52,9 @@
                         </div>
                         <div class="downloadButtonsContainer">
                             {% if site.playstore_link %}
-                                <a class="playStoreLink" href=""><img class="playStore" src="assets/playstore.png"></a>
+                                <a class="playStoreLink" href="{{site.playstore_link}}"><img class="playStore" src="assets/playstore.png"></a>
                             {% endif %}
-                            <a class="appStoreLink" href=""><img class="appStore" src="assets/appstore.png"></a>
+                            <a class="appStoreLink" href="{{site.appstore_link}}"><img class="appStore" src="assets/appstore.png"></a>
                         </div>
                     </div>
                     {% include features.html %}


### PR DESCRIPTION
1. Even you set a custom App Store link, it will not change the link.  The following two commits fixed this bug:
   5c5d768 
   cb3172d
The first commit has a problem and the second amended it.

2. The title is not populated properly and the following commit fixed it:
365f5b5 
Besides, it also added support for manually setting page title if you want it to be more informative than just app name.