### PR TITLE
Support itms apps link (open app in app store)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ page_title                                :                                     
 ios_app_id                                : 1234793120                                # Required. Enter iOS app ID to automatically populate name, price and icons (e.g. 718043190).
 
 appstore_link                             :                                           # Automatically populates if not set and if iOS app ID is set. Otherwise enter manually.
+use_itms_apps_link                        : false
 playstore_link                            :                                           # Enter Google Play Store URL.
 presskit_download_link                    :                                           # Enter a link to downloadable file or (e.g. public Dropbox link to a .zip file). 
                                                                                       # Or upload your press kit file to assets and set path accordingly (e.g. "assets/your_press_kit.zip").

--- a/_includes/appstoreimages.html
+++ b/_includes/appstoreimages.html
@@ -52,8 +52,13 @@ $(function() {
 
             // Set App Store link using the iOS app ID if it is not set manually in _config.yml
             var $appStoreLink = $(".appStoreLink");
+            var url =appInfo.trackViewUrl;
+            if ("{{site.use_itms_apps_link}}" == "true") {
+                url = "itms-apps://apps.apple.com/us/app/" + appInfo.trackName +"/{{ site.ios_app_id }}";
+            }
+
             if ($.trim($appStoreLink.attr('href')).length == 0) {
-                $($appStoreLink).attr("href", appInfo.trackViewUrl);
+                $($appStoreLink).attr("href", url);
             }
 
             console.info(appInfo);


### PR DESCRIPTION
Bug: If you open the website using the Chrome app on iPhone, "download from app store" is not working
Why: Chrome does not support open a link from the AppStore
Solution: Use `itms-app://` to open the app from AppStore

Possible problem: if the user clicks this link on non-iOS device, then the link is not going to work. But if the user clicks "download from app store" their intent is to "download it from the app store" and they must be on an iOS device. So I think it is okay - I want to leave this up to the person fork the website, so I make it an option in the config file `use_itms_apps_link`

Let me know if you have any other solutions or suggestions for this. Thanks!