### PR TITLE
Hide footer text when the name is not provided in the configuration file.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,7 @@
 <footer>
+	{% if site.your_name %}
 	<p class="footerText">Made by {% if site.your_link %}<a href="{{ site.your_link }}">{% endif %}{{ site.your_name }}{% if site.your_link %}</a>{% endif %}{% if site.your_city %} in {{ site.your_city }}{% endif %}</p>
+	{% endif %}
 	<div class="footerIcons">
 
 		{% if site.facebook_username %}


### PR DESCRIPTION
Thanks a lot for creating and sharing this great project @emilbaehr.

It was really useful to create the website of my App ([kyoku.app](https://kyoku.app)) 

Please find here a small contribution with this Pull Request.

I noticed that when no value is given to the key "your_name" in the configuration file, the footer is still presented only showing the "Made by" prefix.

<img width="262" alt="Screenshot 2019-12-23 at 20 48 23" src="https://user-images.githubusercontent.com/2320840/71377594-9530a680-25c5-11ea-9567-8bcb656d8aba.png">

This PR introduces a new condition to avoid showing the whole footer text when no name is given.