### PR TITLE
Separate header and app name overwrites

### DIFF
--- a/_includes/appstoreimages.html
+++ b/_includes/appstoreimages.html
@@ -38,9 +38,13 @@ $(function() {
 
             // Set app name using the iOS app ID if it is not set manually in _config.yml
             var $appName = $(".appName");
-            var $headerName = $(".headerName");
             if ($.trim($($appName).text()).length == 0) {
                 $($appName).html(appInfo.trackName);
+            }
+
+            // Set the name displayed in the header if it is not set manually in _config.yml
+            var $headerName = $(".headerName");
+            if ($.trim($($headerName).text()).length == 0) {
                 $($headerName).html(appInfo.trackName);
             }
 


### PR DESCRIPTION
Currently the headerName field is overwritten by the name from the app store regardless of whether or not it is specified in the config.yml file on pages other than index.html. Separating the logic for overwriting the appName and the headerName allows the headerName to retain it's value from the config if it is set.