### PR TITLE
Use site.url instead of hardcoded paths wherever possible

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
 #page title
 page_title                                :                                           # Automatically populates with app name if not set and if iOS app ID is set. Otherwise enter manually.
+url                                       : https://emilbaehr.github.io/              # The URL of your github pages site
 
 # App Info
 ios_app_id                                : 1234793120                                # Required. Enter iOS app ID to automatically populate name, price and icons (e.g. 718043190).

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,7 +15,5 @@
 	{% endif %}
 
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
-	<link rel="stylesheet" href="/main.css">
-	<link rel="stylesheet" href="main.css">
-	<link rel="stylesheet" href="../main.css">
+	<link rel="stylesheet" href="{{ site.url }}/main.css">
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,7 +9,7 @@
 				</defs>
 			</svg>
 			{% if page.url != '/' %}
-				<a href="../" target="_self"><img class="headerIcon" src="{{ site.app_icon }}"></a>
+				<a href="{{ site.url }}" target="_self"><img class="headerIcon" src="{{ site.app_icon }}"></a>
 			{% else %}
 				<img class="headerIcon" src="{{ site.app_icon }}">
 			{% endif %}


### PR DESCRIPTION
Found a couple of places where `site.url` probably ought to be used. When using this template for my own site, I found that pages that were nested more than one level deep couldn't get back to the home page with the icon link in the header. Additionally those nested pages could not fetch the main css file.