### PR TITLE
Update Main.css and App Store Icon to Use Relative URLs

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,7 +7,7 @@
 	<title class="pageTitle">{{ site.page_title }}</title>
 	<meta name="description" content="{{ site.app_description }}">
 
-	<link rel="shortcut icon" href="{{ site.app_icon }}">
+	<link rel="shortcut icon" href="{{ site.app_icon | relative_url }}">
 
 	<!-- Smart App Banner -->
 	{% if site.enable_smart_app_banner %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,7 +15,5 @@
 	{% endif %}
 
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
-	<link rel="stylesheet" href="/main.css">
-	<link rel="stylesheet" href="main.css">
-	<link rel="stylesheet" href="../main.css">
+	<link rel="stylesheet" href="{{ '/main.css' | relative_url }}">
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,9 +9,9 @@
 				</defs>
 			</svg>
 			{% if page.url != '/' %}
-				<a href="../" target="_self"><img class="headerIcon" src="{{ site.app_icon }}"></a>
+				<a href="../" target="_self"><img class="headerIcon" src="{{ site.app_icon | relative_url }}"></a>
 			{% else %}
-				<img class="headerIcon" src="{{ site.app_icon }}">
+				<img class="headerIcon" src="{{ site.app_icon | relative_url }}">
 			{% endif %}
 			<div class="divider"></div>
 		</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -35,7 +35,7 @@
                                     </clipPath>
                                 </defs>
                             </svg>
-                            <img class="appIconLarge" src="{{ site.app_icon }}">
+                            <img class="appIconLarge" src="{{ site.app_icon | relative_url }}">
                         </div>
                         <div class="appNamePriceContainer">
                             <h1 class="appName">


### PR DESCRIPTION
When manually setting an app store icon, the icon fails to load in the changelog page due to an incorrect url path.