### PR TITLE
Add support for Mastodon

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,7 @@ instagram_username                        : ebaehr
 twitter_username                          : ebaehr
 github_username                           : emilbaehr
 youtube_username                          :
+mastodon_link                             : https://mastodon.social/@ebaehr
 
 
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -31,6 +31,15 @@
 			</a>
 		{% endif %}
 
+		{% if site.mastodon_link %}
+			<a rel="me" href="{{ site.mastodon_link }}">
+				<span class="fa-stack fa-1x">
+					<i class="socialIconBack fas fa-circle fa-stack-2x"></i>
+					<i class="socialIconTop fab fa-mastodon fa-stack-1x"></i>
+				</span>
+			</a>
+		{% endif %}
+
 		{% if site.github_username %}
 			<a href="https://github.com/{{ site.github_username }}">
 				<span class="fa-stack fa-1x">


### PR DESCRIPTION
The `rel="me"` attribute is added to the link so that the landing page can be verified by Mastodon by simply adding the link to your profile.