### PR TITLE
Add include_in_footer setting for footer link visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The videos and screenshots must have one of the following resolutions:
 Your site automatically includes pages for a Privacy Policy and a Changelog. Change the content of these pages by editing the `privacypolicy.md` and `CHANGELOG.md` files in the `_pages` directory.
 
 In each of the markdown files, you can set the `include_in_header:` value to either `true` or `false`. This determines if the page is included in the top navigation.
+You can also set `include_in_footer: false` to exclude a page from the links in the footer. Pages are included in the footer by default.
 By default, only the Changelog is included in the top navigation. The title of the navigation item can also be edited, by editing the `title:` in each markdown file.
 
 If you need to, you can create additional markdown based pages just by creating an `.md` file like the `privacypolicy.md` and `CHANGELOG.md` files in the `_pages` directory.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -79,7 +79,9 @@
 	</div>
 	<div class="footerLinks">
 		{% for page in site.pages %}
-			<a href="{{ page.url | relative_url }}" target="_self">{{ page.title }}</a>
+			{% unless page.include_in_footer == false %}
+				<a href="{{ page.url | relative_url }}" target="_self">{{ page.title }}</a>
+			{% endunless %}
 		{% endfor %}
 		{% if site.presskit_download_link %}
 			<a href="{{ site.presskit_download_link }}">Press Kit</a>


### PR DESCRIPTION
This adds support for a new `include_in_footer` front matter setting, complementing the existing `include_in_header`. Setting `include_in_footer: false` on a page excludes it from the footer links while keeping the page itself published and accessible by URL; useful for pages you link to directly, without listing them in the footer.

**Important** Unlike `include_in_header`, the flag is _opt-out:_ pages without it continue to appear in the footer, so existing sites are unaffected by this change.